### PR TITLE
Adding more ways to associate a launched app with the ApplicationUnderTest

### DIFF
--- a/AFrame.Desktop/DesktopContext.cs
+++ b/AFrame.Desktop/DesktopContext.cs
@@ -19,17 +19,17 @@ namespace AFrame.Desktop
             : this(null, null)
         { }
 
-        internal DesktopContext(IContext parentContext, SearchPropertyStack searchParamters)
-            : base(parentContext, searchParamters)
-        {}
+        internal DesktopContext(IContext parentContext, SearchPropertyStack searchParameters)
+            : base(parentContext, searchParameters)
+        { }
 
         public override void Dispose()
         {
-            if(this.ApplicationUnderTest != null)
+            if (this.ApplicationUnderTest != null)
                 this.ApplicationUnderTest.Dispose();
         }
 
-        public T Launch<T>(string appPath) where T : DesktopControl
+        public T Launch<T>(ProcessStartInfo startInfo) where T : DesktopControl
         {
             AFrame.Core.Playback.HighlightOnFind = false;
 
@@ -42,12 +42,12 @@ namespace AFrame.Desktop
             Mouse.MouseDragSpeed = 0;
             Mouse.MouseMoveSpeed = 0;
 
-            this.ApplicationUnderTest = ApplicationUnderTest.Launch(appPath);
+            this.ApplicationUnderTest = ApplicationUnderTest.Launch(startInfo);
 
             return this.As<T>();
         }
 
-        public T Launch<T>(ProcessStartInfo appPath) where T : DesktopControl
+        public T Launch<T>(string fileName) where T : DesktopControl
         {
             AFrame.Core.Playback.HighlightOnFind = false;
 
@@ -60,9 +60,82 @@ namespace AFrame.Desktop
             Mouse.MouseDragSpeed = 0;
             Mouse.MouseMoveSpeed = 0;
 
-            this.ApplicationUnderTest = ApplicationUnderTest.Launch(appPath);
+            this.ApplicationUnderTest = ApplicationUnderTest.Launch(fileName);
 
             return this.As<T>();
         }
+
+        public T Launch<T>(string fileName, string alternativeFileName) where T : DesktopControl
+        {
+            AFrame.Core.Playback.HighlightOnFind = false;
+
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.SmartMatchOptions = Microsoft.VisualStudio.TestTools.UITest.Extension.SmartMatchOptions.None;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.ShouldSearchFailFast = true;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.MatchExactHierarchy = true;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.DelayBetweenActions = 0;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.SearchTimeout = AFrame.Core.Playback.SearchTimeout;
+
+            Mouse.MouseDragSpeed = 0;
+            Mouse.MouseMoveSpeed = 0;
+
+            this.ApplicationUnderTest = ApplicationUnderTest.Launch(fileName, alternativeFileName);
+
+            return this.As<T>();
+        }
+
+        public T Launch<T>(string fileName, string alternativeFileName, string arguments) where T : DesktopControl
+        {
+            AFrame.Core.Playback.HighlightOnFind = false;
+
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.SmartMatchOptions = Microsoft.VisualStudio.TestTools.UITest.Extension.SmartMatchOptions.None;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.ShouldSearchFailFast = true;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.MatchExactHierarchy = true;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.DelayBetweenActions = 0;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.SearchTimeout = AFrame.Core.Playback.SearchTimeout;
+
+            Mouse.MouseDragSpeed = 0;
+            Mouse.MouseMoveSpeed = 0;
+
+            this.ApplicationUnderTest = ApplicationUnderTest.Launch(fileName, alternativeFileName, arguments);
+
+            return this.As<T>();
+        }
+
+        public T Launch<T>(string fileName, string alternativeFileName, string arguments, string userName, System.Security.SecureString password, string domain) where T : DesktopControl
+        {
+            AFrame.Core.Playback.HighlightOnFind = false;
+
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.SmartMatchOptions = Microsoft.VisualStudio.TestTools.UITest.Extension.SmartMatchOptions.None;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.ShouldSearchFailFast = true;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.MatchExactHierarchy = true;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.DelayBetweenActions = 0;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.SearchTimeout = AFrame.Core.Playback.SearchTimeout;
+
+            Mouse.MouseDragSpeed = 0;
+            Mouse.MouseMoveSpeed = 0;
+
+            this.ApplicationUnderTest = ApplicationUnderTest.Launch(fileName, alternativeFileName, arguments, userName, password, domain);
+
+            return this.As<T>();
+        }
+
+        public T FromProcess<T>(Process processToWrap) where T : DesktopControl
+        {
+            AFrame.Core.Playback.HighlightOnFind = false;
+
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.SmartMatchOptions = Microsoft.VisualStudio.TestTools.UITest.Extension.SmartMatchOptions.None;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.ShouldSearchFailFast = true;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.MatchExactHierarchy = true;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.DelayBetweenActions = 0;
+            Microsoft.VisualStudio.TestTools.UITesting.Playback.PlaybackSettings.SearchTimeout = AFrame.Core.Playback.SearchTimeout;
+
+            Mouse.MouseDragSpeed = 0;
+            Mouse.MouseMoveSpeed = 0;
+
+            this.ApplicationUnderTest = ApplicationUnderTest.FromProcess(processToWrap);
+
+            return this.As<T>();
+        }
+
     }
 }

--- a/Tests/AFrame.Desktop.Tests/AFrame.Desktop.Tests.csproj
+++ b/Tests/AFrame.Desktop.Tests/AFrame.Desktop.Tests.csproj
@@ -51,6 +51,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DesktopContextTests.cs" />
     <Compile Include="WinForms\App\WinFormsApp.cs" />
     <Compile Include="BaseTest.cs" />
     <Compile Include="WinForms\Features\FindTests.cs" />

--- a/Tests/AFrame.Desktop.Tests/DesktopContextTests.cs
+++ b/Tests/AFrame.Desktop.Tests/DesktopContextTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UITesting;
+using AFrame.Desktop.Tests.Wpf.App;
+using System.Diagnostics;
+
+namespace AFrame.Desktop.Tests
+{
+    [CodedUITest]
+    public class DesktopContextTests : BaseTest
+    {
+        [TestMethod]
+        public void LaunchUsingProcessStartInfo()
+        {
+            var startInfo = new ProcessStartInfo(this.WpfAppPath);
+
+            Assert.IsNotNull(this.Context);
+            Assert.IsNull(this.Context.ApplicationUnderTest);
+
+            var app = this.Context.Launch<WpfApp>(startInfo);
+
+            Assert.IsNotNull(this.Context);
+            Assert.IsNotNull(this.Context.ApplicationUnderTest);
+        }
+
+        [TestMethod]
+        public void LaunchUsingFilename()
+        {
+            Assert.IsNotNull(this.Context);
+            Assert.IsNull(this.Context.ApplicationUnderTest);
+
+            var app = this.Context.Launch<WpfApp>(this.WpfAppPath);
+
+            Assert.IsNotNull(this.Context);
+            Assert.IsNotNull(this.Context.ApplicationUnderTest);
+        }
+
+        [TestMethod]
+        public void LaunchUsingFilenameAlternativeFilename()
+        {
+            Assert.IsNotNull(this.Context);
+            Assert.IsNull(this.Context.ApplicationUnderTest);
+
+            var app = this.Context.Launch<WpfApp>(this.WpfAppPath + "x", this.WinFormsAppPath);
+
+            Assert.IsNotNull(this.Context);
+            Assert.IsNotNull(this.Context.ApplicationUnderTest);
+        }
+
+        [TestMethod]
+        public void LaunchUsingFilenameAlternativeFilenameArgs()
+        {
+            Assert.IsNotNull(this.Context);
+            Assert.IsNull(this.Context.ApplicationUnderTest);
+
+            var app = this.Context.Launch<WpfApp>(this.WpfAppPath + "x", this.WinFormsAppPath, "-a -b");
+
+            Assert.IsNotNull(this.Context);
+            Assert.IsNotNull(this.Context.ApplicationUnderTest);
+        }
+
+        //[TestMethod]
+        //public void LaunchUsingFilenameAlternativeFilenameArgsUsernamePasswordDomain()
+        //{
+        //    var secure = new System.Security.SecureString();
+        //    secure.AppendChar('p');
+        //    secure.AppendChar('a');
+        //    secure.AppendChar('s');
+        //    secure.AppendChar('s');
+        //    secure.AppendChar('w');
+        //    secure.AppendChar('o');
+        //    secure.AppendChar('r');
+        //    secure.AppendChar('d');
+
+            //Assert.IsNotNull(this.Context);
+            //Assert.IsNull(this.Context.ApplicationUnderTest);
+
+        //    var app = this.Context.Launch<WpfApp>(this.WpfAppPath + "x", this.WinFormsAppPath, "-a -b", "jim", secure, "domain");
+
+        //    Assert.IsNotNull(this.Context);
+        //    Assert.IsNotNull(this.Context.ApplicationUnderTest);
+        //}
+
+        [TestMethod]
+        public void LaunchFromProcess()
+        {
+            var process = Process.Start(this.WpfAppPath);
+
+            Assert.IsNotNull(this.Context);
+            Assert.IsNull(this.Context.ApplicationUnderTest);
+
+            var app = this.Context.FromProcess<WpfApp>(process);
+
+            Assert.IsNotNull(this.Context);
+            Assert.IsNotNull(this.Context.ApplicationUnderTest);
+        }
+    }
+}


### PR DESCRIPTION
Hey Thwaitsey,

I have added some overloads to capture the other ways of setting the ApplicationUnderTest (Launch and FromProcess).  

I have also included some unit tests ... hopefully they're up to your unit testing standard :-)

Cheers,

Corey